### PR TITLE
Make UI more like the go tool: add build cmd and -c and -o options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A cross-platform debugger for Go.
 
 ### How?
 
-`godebug` uses source code generation to instrument your program with debugging calls. [go tool cover](http://blog.golang.org/cover) takes a similar approach to code coverage. When you run `godebug`, it parses your program, instruments function calls, variable declarations, and statement lines, outputs the resulting code somewhere, and runs it. When this modified code runs, it stops at breakpoints and lets you step through the program and inspect variables.
+`godebug` uses source code generation to instrument your program with debugging calls. [go tool cover](http://blog.golang.org/cover) takes a similar approach to code coverage. When you run `godebug`, it parses your program, instruments function calls, variable declarations, and statement lines, outputs the resulting code somewhere, and runs/compiles it. When this modified code runs, it stops at breakpoints and lets you step through the program and inspect variables.
 
 For more detail, see the [end of this README](#how-it-works-more-detail).
 
@@ -33,11 +33,17 @@ If you want to trace the program outside of the main package, list the packages 
 
     $ godebug run -instrument=pkg1,pkg2,pkg3 gofiles... [arguments...]
 
-If you are debugging a test, use 'godebug test':
+If you are debugging a test, use 'godebug test' like you would use 'go test':
 
-    $ godebug test [-instrument pkgs...]
+    $ godebug test [-instrument pkgs...] [packages]
 
-That's it!
+Finally, you can [cross-]compile a debugging binary using 'godebug build':
+
+    $ godebug build [-instrument pkgs...] [-o output] [package]
+
+The compiled binary has no dependencies, so you can build it locally and then debug on i.e. a staging server.
+
+That's it. See 'godebug help' for the full usage.
 
 ### Debugger commands:
 

--- a/cmd.go
+++ b/cmd.go
@@ -58,7 +58,6 @@ The commands are:
     build     compile a debug-ready Go program
     run       compile, run, and debug a Go program
     test      compile, run, and debug Go package tests
-    output    generate debug source code, but do not build or run it
 
 Use "godebug help [command]" for more information about a command.
 `)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -39,6 +39,11 @@ func Generate(prog *loader.Program, getFileBytes func(string) ([]byte, error), w
 		defs = pkgInfo.Defs
 		_types = pkgInfo.Types
 		pkg = pkgInfo.Pkg
+		path := pkg.Path()
+		if !pkgInfo.Importable && strings.HasSuffix(pkgInfo.Pkg.Name(), "_test") {
+			// EXTERNAL TEST package, strip the _test to find the path
+			path = strings.TrimSuffix(pkg.Path(), "_test")
+		}
 		for _, f := range pkgInfo.Files {
 			fs = prog.Fset
 			fname := fs.Position(f.Pos()).Filename
@@ -65,7 +70,7 @@ func Generate(prog *loader.Program, getFileBytes func(string) ([]byte, error), w
 			}
 			astutil.AddNamedImport(fs, f, importName, "github.com/mailgun/godebug/lib")
 			cfg := printer.Config{Mode: printer.UseSpaces | printer.TabIndent, Tabwidth: 8}
-			out := writerFor(pkg.Path(), fname)
+			out := writerFor(path, fname)
 			defer out.Close()
 			_ = cfg.Fprint(out, fs, f)
 			fmt.Fprintln(out, "\nvar", idents.fileContents, "=", quotedContents)

--- a/testdata/help.yaml
+++ b/testdata/help.yaml
@@ -11,6 +11,7 @@ transcript: |
 
     The commands are:
 
+        build     compile a debug-ready Go program
         run       compile, run, and debug a Go program
         test      compile, run, and debug Go package tests
         output    generate debug source code, but do not build or run it
@@ -54,12 +55,14 @@ transcript: |
 invocations:
     - cmd: godebug help run
 transcript: |
-    usage: godebug run [-godebugwork] [-instrument pkgs...] gofiles... [--] [arguments...]
+    usage: godebug run [-godebugwork] [-instrument pkgs...] [-tags 'tag list'] gofiles... [--] [arguments...]
 
-    Run is a wrapper around 'go run'. It generates debugging code for
-    the named Go source files and runs 'go run' on the result.
+    Run emulates 'go run' behavior. It generates debugging code for the
+    named *.go files and then compiles and executes the result.
 
-    Optionally, a '--' argument ends the list of gofiles.
+    Like 'go run' it takes a list of go files which are treated as a
+    single main package. The rest of the arguments is passed to the
+    binary. Optionally, a '--' argument ends the list of gofiles.
 
     By default, godebug generates debugging code only for the named
     Go source files, and not their dependencies. This means that in
@@ -71,20 +74,28 @@ transcript: |
     If -godebugwork is set, godebug will print the name of the
     temporary work directory and not delete it when exiting.
 
+    -tags works like in 'go help build'.
+
 ---
 invocations:
     - cmd: godebug help test
 transcript: |
-    usage: godebug test [-godebugwork] [-instrument pkgs...] [packages] [flags for test binary]
+    usage: godebug test [-godebugwork] [-instrument pkgs...] [-tags 'tag list'] [-c] [-o output] [packages] [flags for test binary]
 
     Test is a wrapper around 'go test'. It generates debugging code for
     the tests in the named packages and runs 'go test' on the result.
 
     As with 'go test', by default godebug test needs no arguments.
 
+    Flags parsing, -c and -o work like for 'go test' - see 'go help test'.
+    The default binary name for -c has the suffix '.test.debug'.
+
+    See also: 'go help testflag'. Note that you have to use the 'test.'
+    prefix like '-test.v'.
+
     By default, godebug generates debugging code only for the named
-    packages, and not their dependencies. This means that in the
-    debugging session you will not be able to step into function
+    Go source files, and not their dependencies. This means that in
+    the debugging session you will not be able to step into function
     calls from imported packages. To instrument other packages,
     pass the -instrument flag. Packages are comma-separated and
     must not be relative.
@@ -92,7 +103,35 @@ transcript: |
     If -godebugwork is set, godebug will print the name of the
     temporary work directory and not delete it when exiting.
 
-    See also: 'go help testflag'.
+    -tags works like in 'go help build'.
+
+---
+invocations:
+    - cmd: godebug help build
+transcript: |
+    usage: godebug build [-godebugwork] [-instrument pkgs...] [-tags 'tag list'] [-o output] [package]
+
+    Build is a wrapper around 'go build'. It generates debugging code for
+    the named target and builds the result.
+
+    Like 'go build' it takes a single main package. If arguments are a list
+    of *.go files they are treated as a single package. Relative packages are
+    not supported - which means you can't leave the package name out, too.
+
+    The output file naming if -o is not passed works like 'go build' (see
+    'go help build') with the addition of the suffix '.debug'.
+
+    By default, godebug generates debugging code only for the named
+    Go source files, and not their dependencies. This means that in
+    the debugging session you will not be able to step into function
+    calls from imported packages. To instrument other packages,
+    pass the -instrument flag. Packages are comma-separated and
+    must not be relative.
+
+    If -godebugwork is set, godebug will print the name of the
+    temporary work directory and not delete it when exiting.
+
+    -tags works like in 'go help build'.
 
 ---
 invocations:

--- a/testdata/help.yaml
+++ b/testdata/help.yaml
@@ -14,7 +14,6 @@ transcript: |
         build     compile a debug-ready Go program
         run       compile, run, and debug a Go program
         test      compile, run, and debug Go package tests
-        output    generate debug source code, but do not build or run it
 
     Use "godebug help [command]" for more information about a command.
 

--- a/testdata/test-filesystem/gopath/src/tags/main.go
+++ b/testdata/test-filesystem/gopath/src/tags/main.go
@@ -1,0 +1,7 @@
+package main
+
+var v = "x"
+
+func main() {
+	println(v)
+}

--- a/testdata/test-filesystem/gopath/src/tags/tagged.go
+++ b/testdata/test-filesystem/gopath/src/tags/tagged.go
@@ -1,0 +1,7 @@
+// +build godebugtest
+
+package main
+
+func init() {
+	v = "y"
+}


### PR DESCRIPTION
Implements the design in #30

See #8

Replaces #27 