### PR TITLE
Use Cmd.CombinedOutput() to get the actual error message

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -669,7 +669,7 @@ func createFileHook(filename, tmpDir string) *os.File {
 
 func getStdLibPkgs() map[string]bool {
 	pkgs := make(map[string]bool)
-	b, err := exec.Command("go", "list", "std").Output()
+	b, err := exec.Command("go", "list", "std").CombinedOutput()
 	if err != nil {
 		fmt.Printf("Failed to identify standard library packages. Here's the error from 'go list std':\n%s\n\nTry running again without passing \"all\" in the -instrument flag.", b)
 	}


### PR DESCRIPTION
Here is the first error I stumbled on after gogetting :

    $ godebug run reorder.go
    Failed to identify standard library packages. Here's the error from 'go list std':
    cmd/addr2line
    cmd/cgo
    cmd/fix
    cmd/go
    cmd/gofmt
    ...200 more lines...

and here is what the true command displays on my system (error on stderr, list items on stdin) :

    $ go list std
    can't load package: package pkg/runtime: C source files not allowed when not using cgo: atomic_amd64x.c cgocall.c defs.c env_posix.c float.c heapdump.c lock_futex.c mcache.c mcentral.c mem_linux.c mfixalloc.c mgc0.c mheap.c msize.c netpoll_epoll.c os_linux.c panic.c parfor.c print.c proc.c race0.c rune.c runtime.c signal_amd64x.c signal_unix.c stack.c sys_x86.c traceback_x86.c vdso_linux_amd64.c zalg_linux_amd64.c zchan_linux_amd64.c zcomplex_linux_amd64.c zcpuprof_linux_amd64.c zhashmap_linux_amd64.c ziface_linux_amd64.c zlfstack_linux_amd64.c zmalloc_linux_amd64.c zmprof_linux_amd64.c znetpoll_linux_amd64.c zrdebug_linux_amd64.c zruntime1_linux_amd64.c zsema_linux_amd64.c zsigqueue_linux_amd64.c zslice_linux_amd64.c zstring_linux_amd64.c zsymtab_linux_amd64.c ztime_linux_amd64.c
    can't load package: package pkg/runtime/debug: C source files not allowed when not using cgo: debug.c
    cmd/addr2line
    cmd/cgo
    cmd/fix
    cmd/go
    cmd/gofmt
    ...200 more lines...
